### PR TITLE
Sort Readdir output

### DIFF
--- a/straw_s3.go
+++ b/straw_s3.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -364,6 +365,7 @@ func (fs *S3StreamStore) Readdir(name string) ([]os.FileInfo, error) {
 		}
 
 		if !*out.IsTruncated {
+			sort.Slice(results, func(i, j int) bool { return results[i].Name() < results[j].Name() })
 			return results, nil
 		}
 


### PR DESCRIPTION
The test expects this sorted these days, so ensure we sort in the s3
backend.  This makes the S3 test pass again.