### PR TITLE
Use a standard "not exist" error

### DIFF
--- a/straw_mem.go
+++ b/straw_mem.go
@@ -91,7 +91,7 @@ func (fs *MemStreamStore) Mkdir(name string, mode os.FileMode) error {
 	for _, elem := range list[0 : len(list)-1] {
 		dir = dir.Entries[elem]
 		if dir == nil {
-			return errors.New("no such file or directory")
+			return os.ErrNotExist
 		}
 	}
 	newdir := list[len(list)-1]
@@ -113,19 +113,19 @@ func (fs *MemStreamStore) Remove(name string) error {
 	for _, elem := range list[0 : len(list)-1] {
 		parent = parent.Entries[elem]
 		if parent == nil {
-			return errors.New("no such file or directory")
+			return os.ErrNotExist
 		}
 	}
 	filename := list[len(list)-1]
 	if parent.Entries == nil {
-		return errors.New("no such file or directory")
+		return os.ErrNotExist
 	}
 	if parent.Entries[filename] == nil {
-		return errors.New("no such file or directory")
+		return os.ErrNotExist
 	}
 	file := parent.Entries[filename]
 	if file == nil {
-		return errors.New("no such file or directory")
+		return os.ErrNotExist
 	}
 	if file.IsDir_ && file.Entries != nil && len(file.Entries) != 0 {
 		return errors.New("directory not empty")
@@ -155,7 +155,7 @@ func (fs *MemStreamStore) getExisting(name string) (*memFile, error) {
 		}
 	}
 	if f == nil {
-		return nil, errors.New("no such file or directory")
+		return nil, os.ErrNotExist
 	}
 	return f, nil
 }

--- a/straw_s3.go
+++ b/straw_s3.go
@@ -96,7 +96,7 @@ func (fs *S3StreamStore) Stat(name string) (os.FileInfo, error) {
 
 	switch len(matching) {
 	case 0:
-		return nil, fmt.Errorf("\"%s\" : no such file or directory", name)
+		return nil, os.ErrNotExist
 	case 2:
 		panic("bug?")
 	default:
@@ -157,7 +157,7 @@ func (fs *S3StreamStore) OpenReadCloser(name string) (io.ReadCloser, error) {
 	if err != nil {
 		if e, ok := err.(awserr.Error); ok {
 			if e.Code() == s3.ErrCodeNoSuchKey {
-				return nil, fmt.Errorf("%s : no such file or directory", name)
+				return nil, os.ErrNotExist
 			}
 		}
 		log.Printf("WARN: unhandled error type :  %T\n", err)

--- a/straw_test.go
+++ b/straw_test.go
@@ -26,7 +26,7 @@ func (fst *fsTester) TestOpenReadCloserNotExisting(t *testing.T) {
 	assert := assert.New(t)
 
 	f, err := fst.fs.OpenReadCloser("/does/not/exist")
-	assert.Condition(func() bool { return strings.HasSuffix(err.Error(), "no such file or directory") }, "error does not match: %s", err.Error())
+	assert.True(os.IsNotExist(err))
 	assert.Nil(f)
 }
 
@@ -179,14 +179,14 @@ func (fst *fsTester) TestMkdirInNonExistingDir(t *testing.T) {
 	name = filepath.Join(name, "innerdir")
 	err := fst.fs.Mkdir(name, 0755)
 
-	assert.Condition(func() bool { return strings.HasSuffix(err.Error(), "no such file or directory") }, "error does not match: %s", err.Error())
+	assert.True(os.IsNotExist(err))
 }
 
 func (fst *fsTester) TestRemoveNonExistingAtRoot(t *testing.T) {
 	assert := assert.New(t)
 
 	err := fst.fs.Remove("not_existing_file")
-	assert.Condition(func() bool { return strings.HasSuffix(err.Error(), "no such file or directory") })
+	assert.True(os.IsNotExist(err))
 }
 
 func (fst *fsTester) TestRemoveNonExistingInSubdir(t *testing.T) {
@@ -197,7 +197,7 @@ func (fst *fsTester) TestRemoveNonExistingInSubdir(t *testing.T) {
 	require.NoError(fst.fs.Mkdir(top, 0755))
 
 	err := fst.fs.Remove(filepath.Join(top, "not_existing_file"))
-	assert.Condition(func() bool { return strings.HasSuffix(err.Error(), "no such file or directory") })
+	assert.True(os.IsNotExist(err))
 }
 
 func (fst *fsTester) TestRemoveParentDirDoesNotExist(t *testing.T) {
@@ -207,7 +207,7 @@ func (fst *fsTester) TestRemoveParentDirDoesNotExist(t *testing.T) {
 	child := filepath.Join(parent, "some_filename")
 
 	err := fst.fs.Remove(child)
-	assert.Condition(func() bool { return strings.HasSuffix(err.Error(), "no such file or directory") })
+	assert.True(os.IsNotExist(err))
 }
 
 func (fst *fsTester) TestRemoveEmptyDir(t *testing.T) {
@@ -228,7 +228,7 @@ func (fst *fsTester) TestRemoveEmptyDir(t *testing.T) {
 	fi, err = fst.fs.Stat(name)
 	assert.Nil(fi)
 	require.NotNil(err)
-	assert.Condition(func() bool { return strings.HasSuffix(err.Error(), "no such file or directory") })
+	assert.True(os.IsNotExist(err))
 }
 
 func (fst *fsTester) TestRemoveNonEmptyDir(t *testing.T) {
@@ -273,7 +273,7 @@ func (fst *fsTester) TestRemoveFileInDir(t *testing.T) {
 	fi, err = fst.fs.Stat(filename)
 	assert.Nil(fi)
 	require.NotNil(err)
-	assert.Condition(func() bool { return strings.HasSuffix(err.Error(), "no such file or directory") })
+	assert.True(os.IsNotExist(err))
 }
 
 func (fst *fsTester) TestOverwrite(t *testing.T) {


### PR DESCRIPTION
Use a os.ErrNotExist, Among other things, this means that os.IsNotExist
does the expected thing.