### PR TITLE
Return custom interfaces from StreamStore

### DIFF
--- a/straw.go
+++ b/straw.go
@@ -5,9 +5,19 @@ import (
 	"os"
 )
 
+type StrawReader interface {
+	io.Reader
+	io.Closer
+}
+
+type StrawWriter interface {
+	io.Writer
+	io.Closer
+}
+
 type StreamStore interface {
-	OpenReadCloser(name string) (io.ReadCloser, error)
-	CreateWriteCloser(name string) (io.WriteCloser, error)
+	OpenReadCloser(name string) (StrawReader, error)
+	CreateWriteCloser(name string) (StrawWriter, error)
 	Lstat(path string) (os.FileInfo, error)
 	Stat(path string) (os.FileInfo, error)
 	Readdir(path string) ([]os.FileInfo, error)

--- a/straw_mem.go
+++ b/straw_mem.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -71,7 +70,7 @@ func (fs *MemStreamStore) Stat(name string) (os.FileInfo, error) {
 	return fs.getExisting(name)
 }
 
-func (fs *MemStreamStore) OpenReadCloser(name string) (io.ReadCloser, error) {
+func (fs *MemStreamStore) OpenReadCloser(name string) (StrawReader, error) {
 	fs.lk.Lock()
 	defer fs.lk.Unlock()
 
@@ -160,7 +159,7 @@ func (fs *MemStreamStore) getExisting(name string) (*memFile, error) {
 	return f, nil
 }
 
-func (fs *MemStreamStore) CreateWriteCloser(name string) (io.WriteCloser, error) {
+func (fs *MemStreamStore) CreateWriteCloser(name string) (StrawWriter, error) {
 	fs.lk.Lock()
 	defer fs.lk.Unlock()
 

--- a/straw_os.go
+++ b/straw_os.go
@@ -2,7 +2,6 @@ package straw
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"sort"
 )
@@ -24,7 +23,7 @@ func (_ *OsStreamStore) Mkdir(path string, mode os.FileMode) error {
 	return os.Mkdir(path, mode)
 }
 
-func (_ *OsStreamStore) OpenReadCloser(name string) (io.ReadCloser, error) {
+func (_ *OsStreamStore) OpenReadCloser(name string) (StrawReader, error) {
 	f, err := os.Open(name)
 	if err != nil {
 		return nil, err
@@ -45,7 +44,7 @@ func (_ *OsStreamStore) Remove(name string) error {
 	return os.Remove(name)
 }
 
-func (_ *OsStreamStore) CreateWriteCloser(name string) (io.WriteCloser, error) {
+func (_ *OsStreamStore) CreateWriteCloser(name string) (StrawWriter, error) {
 	return os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 }
 

--- a/straw_s3.go
+++ b/straw_s3.go
@@ -138,7 +138,7 @@ func (sr *s3StatResult) Sys() interface{} {
 	return nil
 }
 
-func (fs *S3StreamStore) OpenReadCloser(name string) (io.ReadCloser, error) {
+func (fs *S3StreamStore) OpenReadCloser(name string) (StrawReader, error) {
 
 	fi, err := fs.Stat(name)
 	if err != nil {
@@ -235,7 +235,7 @@ func (fs *S3StreamStore) Remove(name string) error {
 	return err
 }
 
-func (fs *S3StreamStore) CreateWriteCloser(name string) (io.WriteCloser, error) {
+func (fs *S3StreamStore) CreateWriteCloser(name string) (StrawWriter, error) {
 	name = fs.noSlashPrefix(name)
 
 	if err := fs.checkParentDir(name); err != nil {


### PR DESCRIPTION
This allows for easier future expansion (a (perhaps unlikely) example
might be that StrawReader adds Seek().