### PR TITLE
Use alternate API for enabling SSE

### DIFF
--- a/straw_s3_options.go
+++ b/straw_s3_options.go
@@ -1,0 +1,16 @@
+package straw
+
+// S3Option is an option to the s3 backend
+type S3Option interface {
+	isS3Opt()
+}
+
+type serverSideEncryptionOpt ServerSideEncryptionType
+
+func (s serverSideEncryptionOpt) isS3Opt() {}
+
+// DeferFieldDecoding instructs the iterator to wait until fields are requested
+// before decoding.
+func S3ServerSideEncoding(sse ServerSideEncryptionType) serverSideEncryptionOpt {
+	return serverSideEncryptionOpt(sse)
+}


### PR DESCRIPTION
This represents the SSE settings as an option.  This means all settings
are set up initially, instead of after the streamstore is created. While
it's not a problem for the sse setting, it might be for other things we
might want to configure soon (e.g, the profile is hard coded to "dev"
right now) so this establishes a good flexible way to do all options.