### PR TITLE
Remove default s3 session options

### DIFF
--- a/straw_s3.go
+++ b/straw_s3.go
@@ -28,12 +28,7 @@ var _ StreamStore = &S3StreamStore{}
 
 func NewS3StreamStore(bucket string, options ...S3Option) (*S3StreamStore, error) {
 
-	sess, err := session.NewSessionWithOptions(
-		session.Options{
-			SharedConfigState: session.SharedConfigEnable,
-			Profile:           "dev",
-		},
-	)
+	sess, err := session.NewSession()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Setting the profile to `dev` will overwrite anything set in the environment making it impossible to use any other profile.