### PR TITLE
Enable shared config state again.

### DIFF
--- a/straw_s3.go
+++ b/straw_s3.go
@@ -28,7 +28,11 @@ var _ StreamStore = &S3StreamStore{}
 
 func NewS3StreamStore(bucket string, options ...S3Option) (*S3StreamStore, error) {
 
-	sess, err := session.NewSession()
+	sess, err := session.NewSessionWithOptions(
+		session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Without this we need to specify `AWS_SDK_LOAD_CONFIG=1` flag if we want the library to take all the auth values from the environment.