### PR TITLE
S3 backed store Lstat() support

### DIFF
--- a/straw_s3.go
+++ b/straw_s3.go
@@ -65,7 +65,8 @@ type S3StreamStore struct {
 }
 
 func (fs *S3StreamStore) Lstat(name string) (os.FileInfo, error) {
-	panic("write me")
+	// S3 does not support symlinks
+	return fs.Stat(name)
 }
 
 func (fs *S3StreamStore) Stat(name string) (os.FileInfo, error) {


### PR DESCRIPTION
This simply returns FileInfo returned by Stat(). S3 doesn't (without
trickery) support symlinks.