### PR TITLE
Add Walk function

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -1,0 +1,75 @@
+package straw
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// SkipDir is used as a return value from WalkFuncs to indicate that
+// the directory named in the call is to be skipped. It is not returned
+// as an error by any function.
+var SkipDir = errors.New("skip this directory")
+
+// WalkFunc is the type of the function called for each file or directory
+// visited by Walk. The path argument contains the argument to Walk as a
+// prefix; that is, if Walk is called with "dir", which is a directory
+// containing the file "a", the walk function will be called with argument
+// "dir/a". The info argument is the os.FileInfo for the named path.
+//
+// If there was a problem walking to the file or directory named by path, the
+// incoming error will describe the problem and the function can decide how
+// to handle that error (and Walk will not descend into that directory). In the
+// case of an error, the info argument will be nil. If an error is returned,
+// processing stops. The sole exception is when the function returns the special
+// value SkipDir. If the function returns SkipDir when invoked on a directory,
+// Walk skips the directory's contents entirely. If the function returns SkipDir
+// when invoked on a non-directory file, Walk skips the remaining files in the
+// containing directory.
+type WalkFunc = func(string, os.FileInfo, error) error
+
+func walk(store StreamStore, path string, info os.FileInfo, walkFn WalkFunc) error {
+
+	if !info.IsDir() {
+		return walkFn(path, info, nil)
+	}
+
+	fileInfos, err := store.Readdir(path)
+	err1 := walkFn(path, info, err)
+
+	if err != nil || err1 != nil {
+		return err1
+	}
+
+	for _, fileInfo := range fileInfos {
+		filename := filepath.Join(path, fileInfo.Name())
+		err = walk(store, filename, fileInfo, walkFn)
+		if err != nil {
+			if !fileInfo.IsDir() || err != SkipDir {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Walk walks the file tree rooted at root, calling walkFn for each file or
+// directory in the tree, including root. All errors that arise visiting files
+// and directories are filtered by walkFn. The files are walked in lexical
+// order, which makes the output deterministic but means that for very
+// large directories Walk can be inefficient.
+// Walk does not follow symbolic links.
+// This is the straw equivalent of filepath.Walk in the standard library.
+func Walk(store StreamStore, root string, walkFn WalkFunc) error {
+	info, err := store.Stat(root)
+	if err != nil {
+		err = walkFn(root, nil, err)
+	} else {
+		err = walk(store, root, info, walkFn)
+	}
+	if err == SkipDir {
+		return nil
+	}
+	return err
+}

--- a/walk_test.go
+++ b/walk_test.go
@@ -1,0 +1,123 @@
+package straw
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWalk(t *testing.T) {
+	assert := assert.New(t)
+
+	ss := NewMemStreamStore()
+
+	ss.Mkdir("a", 0755)
+	writeFile(ss, "a/1")
+	writeFile(ss, "b")
+	ss.Mkdir("c", 0755)
+
+	var found []string
+	var fiNames []string
+	var fiIsDirs []bool
+
+	err := Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		found = append(found, name)
+		fiNames = append(fiNames, fi.Name())
+		fiIsDirs = append(fiIsDirs, fi.IsDir())
+		return nil
+	})
+	assert.NoError(err)
+	assert.Equal([]string{"/", "/a", "/a/1", "/b", "/c"}, found)
+	assert.Equal([]string{"", "a", "1", "b", "c"}, fiNames)
+	assert.Equal([]bool{true, true, false, false, true}, fiIsDirs)
+}
+
+func TestWalkSkipDir(t *testing.T) {
+	assert := assert.New(t)
+
+	ss := NewMemStreamStore()
+
+	ss.Mkdir("a", 0755)
+	writeFile(ss, "a/1")
+	writeFile(ss, "b")
+	ss.Mkdir("c", 0755)
+
+	var found []string
+	var fiNames []string
+	var fiIsDirs []bool
+
+	err := Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if name == "/a" {
+			return SkipDir
+		}
+		found = append(found, name)
+		fiNames = append(fiNames, fi.Name())
+		fiIsDirs = append(fiIsDirs, fi.IsDir())
+		return nil
+	})
+	assert.NoError(err)
+	assert.Equal([]string{"/", "/b", "/c"}, found)
+	assert.Equal([]string{"", "b", "c"}, fiNames)
+	assert.Equal([]bool{true, false, true}, fiIsDirs)
+}
+
+func TestWalkExitOnErr(t *testing.T) {
+	assert := assert.New(t)
+
+	ss := NewMemStreamStore()
+
+	ss.Mkdir("a", 0755)
+	writeFile(ss, "a/1")
+	writeFile(ss, "b")
+	ss.Mkdir("c", 0755)
+
+	var found []string
+	var fiNames []string
+	var fiIsDirs []bool
+
+	someError := errors.New("some random error")
+
+	err := Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if name == "/b" {
+			return someError
+		}
+		found = append(found, name)
+		fiNames = append(fiNames, fi.Name())
+		fiIsDirs = append(fiIsDirs, fi.IsDir())
+		return nil
+	})
+	assert.Equal(err, someError)
+	assert.Equal([]string{"/", "/a", "/a/1"}, found)
+	assert.Equal([]string{"", "a", "1"}, fiNames)
+	assert.Equal([]bool{true, true, false}, fiIsDirs)
+}
+func TestWalkRootNotExist(t *testing.T) {
+	assert := assert.New(t)
+
+	ss := NewMemStreamStore()
+
+	err := Walk(ss, "/this/doesnt/exist", func(name string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		panic("won't get here")
+	})
+	assert.Error(err, "file does not exist")
+}
+
+func writeFile(ss StreamStore, name string) {
+	wc, _ := ss.CreateWriteCloser(name)
+	wc.Write([]byte{0})
+	wc.Close()
+}


### PR DESCRIPTION
This adds a Walk function, which aims to be equivelant to filepath.Walk
in the standard library, and re-uses much of the code in doing so.