### PR TITLE
Introduce URL based store access

### DIFF
--- a/register.go
+++ b/register.go
@@ -1,0 +1,23 @@
+package straw
+
+import (
+	"net/url"
+	"sync"
+)
+
+var (
+	backendsLk sync.RWMutex
+	backends   = make(map[string]func(url *url.URL) (StreamStore, error))
+)
+
+func Register(scheme string, sinkFunc func(url *url.URL) (StreamStore, error)) {
+	backendsLk.Lock()
+	defer backendsLk.Unlock()
+	if sinkFunc == nil {
+		panic("straw: sink function is nil")
+	}
+	if _, dup := backends[scheme]; dup {
+		panic("straw: RegisterSink called more than once for sink " + scheme)
+	}
+	backends[scheme] = sinkFunc
+}

--- a/strawurl.go
+++ b/strawurl.go
@@ -1,0 +1,50 @@
+package straw
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func Open(u string) (StreamStore, error) {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	backendsLk.RLock()
+	defer backendsLk.RUnlock()
+
+	f := backends[parsed.Scheme]
+	if f == nil {
+		return nil, fmt.Errorf("unknown scheme : %s", parsed.Scheme)
+	}
+	return f(parsed)
+}
+
+func init() {
+	Register("file", func(u *url.URL) (StreamStore, error) {
+		return &OsStreamStore{}, nil
+	})
+	Register("gs", func(u *url.URL) (StreamStore, error) {
+		creds := u.Query().Get("credentialsfile")
+		if creds == "" {
+			return nil, fmt.Errorf("gs URLs must provide a `credentialsfile` parameter")
+		}
+		return NewGCSStreamStore(creds, u.Host)
+	})
+	Register("s3", func(u *url.URL) (StreamStore, error) {
+		sse := u.Query().Get("sse")
+		var opts []S3Option
+		switch sse {
+		case "":
+		case "AES256":
+			opts = append(opts, S3ServerSideEncoding(ServerSideEncryptionTypeAES256))
+		default:
+			return nil, fmt.Errorf("unknown server side encryption type '%s'", sse)
+		}
+		return NewS3StreamStore(u.Host, opts...)
+	})
+	Register("sftp", func(u *url.URL) (StreamStore, error) {
+		return NewSFTPStreamStore(u.String())
+	})
+}


### PR DESCRIPTION
This brings a URL based approach for accessing a store, meaning that
applications can switch between one store type and another by a config
change alone.

This is modelled on how `database/sql` works.

Updates #21 