### PR TITLE
Move backends to seperate packages

### DIFF
--- a/s3/straw_s3_options.go
+++ b/s3/straw_s3_options.go
@@ -1,4 +1,4 @@
-package straw
+package s3
 
 // S3Option is an option to the s3 backend
 type S3Option interface {

--- a/sftp/straw_sftp.go
+++ b/sftp/straw_sftp.go
@@ -1,4 +1,4 @@
-package straw
+package sftp
 
 import (
 	"errors"
@@ -12,10 +12,17 @@ import (
 	"sync"
 
 	"github.com/pkg/sftp"
+	"github.com/uw-labs/straw"
 	"golang.org/x/crypto/ssh"
 )
 
-var _ StreamStore = &SFTPStreamStore{}
+var _ straw.StreamStore = &SFTPStreamStore{}
+
+func init() {
+	straw.Register("sftp", func(u *url.URL) (straw.StreamStore, error) {
+		return NewSFTPStreamStore(u.String())
+	})
+}
 
 type SFTPStreamStore struct {
 	sshClient  *ssh.Client
@@ -74,7 +81,7 @@ func (s *SFTPStreamStore) Mkdir(path string, mode os.FileMode) error {
 	return err
 }
 
-func (s *SFTPStreamStore) OpenReadCloser(name string) (StrawReader, error) {
+func (s *SFTPStreamStore) OpenReadCloser(name string) (straw.StrawReader, error) {
 	sr, err := s.sftpClient.Open(name)
 	if err != nil {
 		return nil, err
@@ -99,7 +106,7 @@ func (s *SFTPStreamStore) Remove(name string) error {
 	return err
 }
 
-func (s *SFTPStreamStore) CreateWriteCloser(name string) (StrawWriter, error) {
+func (s *SFTPStreamStore) CreateWriteCloser(name string) (straw.StrawWriter, error) {
 	fi, err := s.Stat(name)
 	if err == nil && fi.IsDir() {
 		return nil, fmt.Errorf("%s is a directory", name)

--- a/strawurl.go
+++ b/strawurl.go
@@ -22,29 +22,8 @@ func Open(u string) (StreamStore, error) {
 }
 
 func init() {
+	// the only "built in" backend is "file"
 	Register("file", func(u *url.URL) (StreamStore, error) {
 		return &OsStreamStore{}, nil
-	})
-	Register("gs", func(u *url.URL) (StreamStore, error) {
-		creds := u.Query().Get("credentialsfile")
-		if creds == "" {
-			return nil, fmt.Errorf("gs URLs must provide a `credentialsfile` parameter")
-		}
-		return NewGCSStreamStore(creds, u.Host)
-	})
-	Register("s3", func(u *url.URL) (StreamStore, error) {
-		sse := u.Query().Get("sse")
-		var opts []S3Option
-		switch sse {
-		case "":
-		case "AES256":
-			opts = append(opts, S3ServerSideEncoding(ServerSideEncryptionTypeAES256))
-		default:
-			return nil, fmt.Errorf("unknown server side encryption type '%s'", sse)
-		}
-		return NewS3StreamStore(u.Host, opts...)
-	})
-	Register("sftp", func(u *url.URL) (StreamStore, error) {
-		return NewSFTPStreamStore(u.String())
 	})
 }


### PR DESCRIPTION
This moves the backends each to its own package, so that users do not
have to include support for every backend (and the somewhat large
dependencies associated with them) even if they are not needed.

To enable a backend for url based usage, simply do an anonymous import,
just as you would with a sql driver.

Note that this represents a breaking API change.

Fixes #20
Updates #21 and #22