### PR TITLE
Begin to make URLs the primary way to use straw

### DIFF
--- a/straw_logging_streamstore_test.go
+++ b/straw_logging_streamstore_test.go
@@ -1,17 +1,19 @@
-package straw
+package straw_test
 
 import (
 	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/uw-labs/straw"
 )
 
-var _ StreamStore = &TestLogStreamStore{}
+var _ straw.StreamStore = &TestLogStreamStore{}
 
 type TestLogStreamStore struct {
 	t       *testing.T
-	wrapped StreamStore
+	wrapped straw.StreamStore
 }
 
 func (fs *TestLogStreamStore) Lstat(name string) (os.FileInfo, error) {
@@ -26,7 +28,7 @@ func (fs *TestLogStreamStore) Stat(name string) (os.FileInfo, error) {
 	return fs.wrapped.Stat(name)
 }
 
-func (fs *TestLogStreamStore) OpenReadCloser(name string) (StrawReader, error) {
+func (fs *TestLogStreamStore) OpenReadCloser(name string) (straw.StrawReader, error) {
 	fs.before("Open", name)
 	defer fs.after("Open", name)
 	return fs.wrapped.OpenReadCloser(name)
@@ -44,7 +46,7 @@ func (fs *TestLogStreamStore) Remove(name string) error {
 	return fs.wrapped.Remove(name)
 }
 
-func (fs *TestLogStreamStore) CreateWriteCloser(name string) (StrawWriter, error) {
+func (fs *TestLogStreamStore) CreateWriteCloser(name string) (straw.StrawWriter, error) {
 	fs.before("CreateWriteOnly", name)
 	defer fs.after("CreateWriteOnly", name)
 	return fs.wrapped.CreateWriteCloser(name)

--- a/straw_test.go
+++ b/straw_test.go
@@ -19,6 +19,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uw-labs/straw"
 	"golang.org/x/crypto/ssh"
+
+	_ "github.com/uw-labs/straw/gcs"
+	_ "github.com/uw-labs/straw/s3"
+	_ "github.com/uw-labs/straw/sftp"
 )
 
 type fsTester struct {
@@ -614,7 +618,7 @@ func TestS3FS(t *testing.T) {
 		t.Skip("S3_TEST_BUCKET not set, skipping tests for s3 backend")
 	}
 
-	s3fs, err := straw.NewS3StreamStore(testBucket)
+	s3fs, err := straw.Open(fmt.Sprintf("s3://%s/", testBucket))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -631,7 +635,7 @@ func TestGCSFS(t *testing.T) {
 		t.Skip("GCS_TEST_CREDENTIALS_FILE not set, skipping tests for gcs backend")
 	}
 
-	gcsFs, err := straw.NewGCSStreamStore(testGCSCredentials, testBucket)
+	gcsFs, err := straw.Open(fmt.Sprintf("gs://%s/?credentialsfile=%s", testBucket, testGCSCredentials))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -641,7 +645,7 @@ func TestGCSFS(t *testing.T) {
 func TestSFTPFS(t *testing.T) {
 	go startSFTPServer()
 
-	sftpfs, err := straw.NewSFTPStreamStore("sftp://test:tiger@localhost:9922/")
+	sftpfs, err := straw.Open("sftp://test:tiger@localhost:9922/")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/straw_test.go
+++ b/straw_test.go
@@ -1,4 +1,4 @@
-package straw
+package straw_test
 
 import (
 	"crypto/ed25519"
@@ -17,13 +17,14 @@ import (
 	"github.com/pkg/sftp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uw-labs/straw"
 	"golang.org/x/crypto/ssh"
 )
 
 type fsTester struct {
 	name     string
-	fs       StreamStore
-	ff       func() StreamStore
+	fs       straw.StreamStore
+	ff       func() straw.StreamStore
 	testRoot string
 }
 
@@ -507,7 +508,7 @@ func (fst *fsTester) TestReadAtWithRead(t *testing.T) {
 
 }
 
-func (fst *fsTester) writeFile(fs StreamStore, name string, data []byte) error {
+func (fst *fsTester) writeFile(fs straw.StreamStore, name string, data []byte) error {
 	w, err := fs.CreateWriteCloser(name)
 	if err != nil {
 		return err
@@ -600,11 +601,11 @@ func tempDir() string {
 }
 
 func TestOSFS(t *testing.T) {
-	testFS(t, "osfs", func() StreamStore { return &TestLogStreamStore{t, &OsStreamStore{}} }, tempDir())
+	testFS(t, "osfs", func() straw.StreamStore { return &TestLogStreamStore{t, &straw.OsStreamStore{}} }, tempDir())
 }
 
 func TestMemFS(t *testing.T) {
-	testFS(t, "memfs", func() StreamStore { return &TestLogStreamStore{t, NewMemStreamStore()} }, "/")
+	testFS(t, "memfs", func() straw.StreamStore { return &TestLogStreamStore{t, straw.NewMemStreamStore()} }, "/")
 }
 
 func TestS3FS(t *testing.T) {
@@ -613,11 +614,11 @@ func TestS3FS(t *testing.T) {
 		t.Skip("S3_TEST_BUCKET not set, skipping tests for s3 backend")
 	}
 
-	s3fs, err := NewS3StreamStore(testBucket)
+	s3fs, err := straw.NewS3StreamStore(testBucket)
 	if err != nil {
 		t.Fatal(err)
 	}
-	testFS(t, "s3fs", func() StreamStore { return &TestLogStreamStore{t, s3fs} }, "/")
+	testFS(t, "s3fs", func() straw.StreamStore { return &TestLogStreamStore{t, s3fs} }, "/")
 }
 
 func TestGCSFS(t *testing.T) {
@@ -630,17 +631,17 @@ func TestGCSFS(t *testing.T) {
 		t.Skip("GCS_TEST_CREDENTIALS_FILE not set, skipping tests for gcs backend")
 	}
 
-	gcsFs, err := NewGCSStreamStore(testGCSCredentials, testBucket)
+	gcsFs, err := straw.NewGCSStreamStore(testGCSCredentials, testBucket)
 	if err != nil {
 		t.Fatal(err)
 	}
-	testFS(t, "gcsfs", func() StreamStore { return &TestLogStreamStore{t, gcsFs} }, "/")
+	testFS(t, "gcsfs", func() straw.StreamStore { return &TestLogStreamStore{t, gcsFs} }, "/")
 }
 
 func TestSFTPFS(t *testing.T) {
 	go startSFTPServer()
 
-	sftpfs, err := NewSFTPStreamStore("sftp://test:tiger@localhost:9922/")
+	sftpfs, err := straw.NewSFTPStreamStore("sftp://test:tiger@localhost:9922/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +649,7 @@ func TestSFTPFS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testFS(t, "sftpfs", func() StreamStore { return &TestLogStreamStore{t, sftpfs} }, dir)
+	testFS(t, "sftpfs", func() straw.StreamStore { return &TestLogStreamStore{t, sftpfs} }, dir)
 }
 
 func startSFTPServer() {
@@ -742,7 +743,7 @@ func startSFTPServer() {
 	}
 }
 
-func testFS(t *testing.T, name string, fsProvider func() StreamStore, rootDir string) {
+func testFS(t *testing.T, name string, fsProvider func() straw.StreamStore, rootDir string) {
 	tester := &fsTester{name, nil, fsProvider, rootDir}
 
 	typ := reflect.TypeOf(tester)
@@ -760,9 +761,9 @@ func testFS(t *testing.T, name string, fsProvider func() StreamStore, rootDir st
 func TestMkdirAll(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := NewMemStreamStore()
+	ss := straw.NewMemStreamStore()
 
-	assert.NoError(MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))
+	assert.NoError(straw.MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))
 
 	fis, err := ss.Readdir("/foo/bar/baz/qux/")
 	assert.NoError(err)
@@ -774,8 +775,8 @@ func TestMkdirAll(t *testing.T) {
 func TestMkdirAllExistingNoError(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := NewMemStreamStore()
+	ss := straw.NewMemStreamStore()
 
-	assert.NoError(MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))
-	assert.NoError(MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))
+	assert.NoError(straw.MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))
+	assert.NoError(straw.MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))
 }

--- a/walk_test.go
+++ b/walk_test.go
@@ -1,4 +1,4 @@
-package straw
+package straw_test
 
 import (
 	"errors"
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uw-labs/straw"
 )
 
 func TestWalk(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := NewMemStreamStore()
+	ss := straw.NewMemStreamStore()
 
 	ss.Mkdir("a", 0755)
 	writeFile(ss, "a/1")
@@ -22,7 +23,7 @@ func TestWalk(t *testing.T) {
 	var fiNames []string
 	var fiIsDirs []bool
 
-	err := Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
+	err := straw.Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -40,7 +41,7 @@ func TestWalk(t *testing.T) {
 func TestWalkSkipDir(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := NewMemStreamStore()
+	ss := straw.NewMemStreamStore()
 
 	ss.Mkdir("a", 0755)
 	writeFile(ss, "a/1")
@@ -51,12 +52,12 @@ func TestWalkSkipDir(t *testing.T) {
 	var fiNames []string
 	var fiIsDirs []bool
 
-	err := Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
+	err := straw.Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if name == "/a" {
-			return SkipDir
+			return straw.SkipDir
 		}
 		found = append(found, name)
 		fiNames = append(fiNames, fi.Name())
@@ -72,7 +73,7 @@ func TestWalkSkipDir(t *testing.T) {
 func TestWalkExitOnErr(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := NewMemStreamStore()
+	ss := straw.NewMemStreamStore()
 
 	ss.Mkdir("a", 0755)
 	writeFile(ss, "a/1")
@@ -85,7 +86,7 @@ func TestWalkExitOnErr(t *testing.T) {
 
 	someError := errors.New("some random error")
 
-	err := Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
+	err := straw.Walk(ss, "/", func(name string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -105,9 +106,9 @@ func TestWalkExitOnErr(t *testing.T) {
 func TestWalkRootNotExist(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := NewMemStreamStore()
+	ss := straw.NewMemStreamStore()
 
-	err := Walk(ss, "/this/doesnt/exist", func(name string, fi os.FileInfo, err error) error {
+	err := straw.Walk(ss, "/this/doesnt/exist", func(name string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -116,7 +117,7 @@ func TestWalkRootNotExist(t *testing.T) {
 	assert.Error(err, "file does not exist")
 }
 
-func writeFile(ss StreamStore, name string) {
+func writeFile(ss straw.StreamStore, name string) {
 	wc, _ := ss.CreateWriteCloser(name)
 	wc.Write([]byte{0})
 	wc.Close()


### PR DESCRIPTION
Begin to move to URLs being the primary way to use straw, by updating all of the tests to use URLs.

See individual commits for details.