### PR TITLE
Convert in memory store to URL

### DIFF
--- a/straw_test.go
+++ b/straw_test.go
@@ -613,7 +613,8 @@ func TestOSFS(t *testing.T) {
 }
 
 func TestMemFS(t *testing.T) {
-	testFS(t, "memfs", func() straw.StreamStore { return &TestLogStreamStore{t, straw.NewMemStreamStore()} }, "/")
+	ss, _ := straw.Open("mem://")
+	testFS(t, "memfs", func() straw.StreamStore { return &TestLogStreamStore{t, ss} }, "/")
 }
 
 func TestS3FS(t *testing.T) {
@@ -769,7 +770,7 @@ func testFS(t *testing.T, name string, fsProvider func() straw.StreamStore, root
 func TestMkdirAll(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := straw.NewMemStreamStore()
+	ss, _ := straw.Open("mem://")
 
 	assert.NoError(straw.MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))
 
@@ -783,7 +784,7 @@ func TestMkdirAll(t *testing.T) {
 func TestMkdirAllExistingNoError(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := straw.NewMemStreamStore()
+	ss, _ := straw.Open("mem://")
 
 	assert.NoError(straw.MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))
 	assert.NoError(straw.MkdirAll(ss, "/foo/bar/baz/qux/quux/", 0644))

--- a/walk_test.go
+++ b/walk_test.go
@@ -12,7 +12,7 @@ import (
 func TestWalk(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := straw.NewMemStreamStore()
+	ss, _ := straw.Open("mem://")
 
 	ss.Mkdir("a", 0755)
 	writeFile(ss, "a/1")
@@ -41,7 +41,7 @@ func TestWalk(t *testing.T) {
 func TestWalkSkipDir(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := straw.NewMemStreamStore()
+	ss, _ := straw.Open("mem://")
 
 	ss.Mkdir("a", 0755)
 	writeFile(ss, "a/1")
@@ -73,7 +73,7 @@ func TestWalkSkipDir(t *testing.T) {
 func TestWalkExitOnErr(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := straw.NewMemStreamStore()
+	ss, _ := straw.Open("mem://")
 
 	ss.Mkdir("a", 0755)
 	writeFile(ss, "a/1")
@@ -106,7 +106,7 @@ func TestWalkExitOnErr(t *testing.T) {
 func TestWalkRootNotExist(t *testing.T) {
 	assert := assert.New(t)
 
-	ss := straw.NewMemStreamStore()
+	ss, _ := straw.Open("mem://")
 
 	err := straw.Walk(ss, "/this/doesnt/exist", func(name string, fi os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
Introduce `mem://` for the memory backend, and unexport the previous way
to do this.