### PR TITLE
Add Close method to StreamStore

### DIFF
--- a/gcs/straw_gcs.go
+++ b/gcs/straw_gcs.go
@@ -49,6 +49,10 @@ type gcsStreamStore struct {
 	bucket string
 }
 
+func (fs *gcsStreamStore) Close() error {
+	return fs.client.Close()
+}
+
 func (fs *gcsStreamStore) Lstat(name string) (os.FileInfo, error) {
 	// GCS does not support symlinks
 	return fs.Stat(name)

--- a/s3/straw_s3.go
+++ b/s3/straw_s3.go
@@ -56,6 +56,11 @@ type s3StreamStore struct {
 	sseType string
 }
 
+func (fs *s3StreamStore) Close() error {
+	// nothing to close for s3 it seems
+	return nil
+}
+
 func (fs *s3StreamStore) Lstat(name string) (os.FileInfo, error) {
 	// S3 does not support symlinks
 	return fs.Stat(name)

--- a/sftp/straw_sftp.go
+++ b/sftp/straw_sftp.go
@@ -64,6 +64,15 @@ func newSFTPStreamStore(urlString string) (*sftpStreamStore, error) {
 	return ss, nil
 }
 
+func (s *sftpStreamStore) Close() error {
+	e1 := s.sftpClient.Close()
+	e2 := s.sshClient.Close()
+	if e1 != nil {
+		return e1
+	}
+	return e2
+}
+
 func (s *sftpStreamStore) Lstat(filename string) (os.FileInfo, error) {
 	return s.sftpClient.Lstat(filename)
 }

--- a/straw.go
+++ b/straw.go
@@ -18,6 +18,7 @@ type StrawWriter interface {
 }
 
 type StreamStore interface {
+	Close() error
 	OpenReadCloser(name string) (StrawReader, error)
 	CreateWriteCloser(name string) (StrawWriter, error)
 	Lstat(path string) (os.FileInfo, error)

--- a/straw_mem.go
+++ b/straw_mem.go
@@ -69,6 +69,10 @@ func (mf *memFile) Sys() interface{} {
 	return nil
 }
 
+func (fs *memStreamStore) Close() error {
+	return nil
+}
+
 func (fs *memStreamStore) Lstat(name string) (os.FileInfo, error) {
 	return fs.Stat(name)
 }

--- a/straw_os.go
+++ b/straw_os.go
@@ -11,6 +11,10 @@ var _ StreamStore = &osStreamStore{}
 type osStreamStore struct {
 }
 
+func (_ *osStreamStore) Close() error {
+	return nil
+}
+
 func (_ *osStreamStore) Lstat(filename string) (os.FileInfo, error) {
 	return os.Lstat(filename)
 }


### PR DESCRIPTION
Some backends have resource deallocation to do, so add Close() to enable
this.